### PR TITLE
Remove unnecessary parameter from docker run

### DIFF
--- a/assignments/all.md
+++ b/assignments/all.md
@@ -185,7 +185,6 @@ To be able to connect to the `redis` container using its host name, we should *l
 ```bash
 docker run \
     -p 80:80 \
-    -v `pwd`/web:/var/www/html \
     -d \
     --link redis \
     --name webserver \


### PR DESCRIPTION
Since we're rebuilding the image beforehand to show that we copy the index.php into the image anyway there is no need to link the index.php folder into the container.